### PR TITLE
Update WorkoutPlanEntity to Include 'isActive' Field

### DIFF
--- a/src/FitSync.API/Controllers/WorkoutPlanController.cs
+++ b/src/FitSync.API/Controllers/WorkoutPlanController.cs
@@ -20,12 +20,13 @@ public class WorkoutPlanController : ControllerBase
         _workoutPlanService = workoutPlanService;
     }
 
-    [HttpGet("users/{userId}")]
+    [HttpGet("users/{userId:int}")]
     [SwaggerOperation("Get Workout Plan by User Id")]
     [SwaggerResponse(StatusCodes.Status200OK, "Workout plan found", typeof(IEnumerable<WorkoutPlanViewModel>))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Workout plan not found")]
     public async Task<IActionResult> GetWorkoutPlansByUserIdAsync([FromRoute] int userId)
     {
+        // TODO: add query to filter by 'isActive' true/false
         _logger.LogInformation("Getting workout plan by user id: {userId}", userId);
         var serviceResponse = await _workoutPlanService.GetWorkoutPlansByUserIdAsync(userId);
 
@@ -34,11 +35,11 @@ public class WorkoutPlanController : ControllerBase
             : NotFound();
     }
 
-    [HttpGet("{id}", Name = nameof(GetWorkoutPlanByIdAsync))]
+    [HttpGet("{id:int}", Name = nameof(GetWorkoutPlanByIdAsync))]
     [SwaggerOperation("Get Workout Plan by Id")]
     [SwaggerResponse(StatusCodes.Status200OK, "Workout plan found", typeof(WorkoutPlanViewModel))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Workout plan not found")]
-    public async Task<IActionResult> GetWorkoutPlanByIdAsync(int id)
+    public async Task<IActionResult> GetWorkoutPlanByIdAsync([FromRoute] int id)
     {
         _logger.LogInformation("Getting workout plan by id: {id}", id);
         var serviceResponse = await _workoutPlanService.GetWorkoutPlanByIdAsync(id);
@@ -83,11 +84,35 @@ public class WorkoutPlanController : ControllerBase
             };
     }
 
-    [HttpDelete("{id}")]
+    [HttpPatch("{id:int}/toggle-active")]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "Workout plan updated")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid workout plan data")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Workout plan not found")]
+    public async Task<IActionResult> ToggleWorkoutPlanActiveAsync([FromRoute] int id, [FromBody] bool
+        isActive)
+    {
+        _logger.LogInformation("{controller} called within {action}", nameof(WorkoutPlanController),
+            nameof(ToggleWorkoutPlanActiveAsync));
+
+        var serviceResponse =
+            await _workoutPlanService.ToggleWorkoutPlanActiveAsync(UpdateWorkoutPlanActiveOrInactiveDto
+            .Create(id, isActive));
+
+        return serviceResponse.Success
+            ? NoContent()
+            : serviceResponse.ErrorMessage switch
+            {
+                "Workout plan not found" => NotFound(),
+                _ => BadRequest(serviceResponse.ErrorMessage)
+            };
+    }
+
+
+    [HttpDelete("{id:int}")]
     [SwaggerOperation("Delete Workout Plan")]
     [SwaggerResponse(StatusCodes.Status204NoContent, "Workout plan deleted")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Workout plan not found")]
-    public async Task<IActionResult> DeleteWorkoutPlanAsync(int id)
+    public async Task<IActionResult> DeleteWorkoutPlanAsync([FromRoute] int id)
     {
         _logger.LogInformation("Deleting workout plan by id: {id}", id);
         var serviceResponse = await _workoutPlanService.DeleteWorkPlanAsync(id);

--- a/src/FitSync.API/Controllers/WorkoutPlanController.cs
+++ b/src/FitSync.API/Controllers/WorkoutPlanController.cs
@@ -24,11 +24,12 @@ public class WorkoutPlanController : ControllerBase
     [SwaggerOperation("Get Workout Plan by User Id")]
     [SwaggerResponse(StatusCodes.Status200OK, "Workout plan found", typeof(IEnumerable<WorkoutPlanViewModel>))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Workout plan not found")]
-    public async Task<IActionResult> GetWorkoutPlansByUserIdAsync([FromRoute] int userId)
+    public async Task<IActionResult> GetWorkoutPlansByUserIdAsync([FromRoute] int userId, [FromQuery] bool isActive =
+        false)
     {
-        // TODO: add query to filter by 'isActive' true/false
+        // TODO: add pagination support
         _logger.LogInformation("Getting workout plan by user id: {userId}", userId);
-        var serviceResponse = await _workoutPlanService.GetWorkoutPlansByUserIdAsync(userId);
+        var serviceResponse = await _workoutPlanService.GetWorkoutPlansByUserIdAsync(userId, isActive);
 
         return serviceResponse.Success
             ? Ok(serviceResponse.Data)

--- a/src/FitSync.Application/Extensions/Map.cs
+++ b/src/FitSync.Application/Extensions/Map.cs
@@ -127,6 +127,7 @@ public static class Map
         return WorkoutPlanViewModel.Create(
             workoutPlanEntity.Id,
             workoutPlanEntity.Name,
+            isActive: workoutPlanEntity.IsActive,
             workoutPlanEntity.WorkoutPlanWorkoutEntities
                 .Select(w => w.Workout
                     .ToViewModel(ExerciseSet.Create(

--- a/src/FitSync.Application/Services/WorkoutPlanService.cs
+++ b/src/FitSync.Application/Services/WorkoutPlanService.cs
@@ -21,6 +21,7 @@ public class WorkoutPlanService : IWorkoutPlanService
 
     public async Task<ServiceResponse<WorkoutPlanViewModel>> GetWorkoutPlanByIdAsync(int id)
     {
+        //TODO: Revisited this to check if is right to filter (First)
         _logger.LogInformation("Getting workout plan by id: {id}", id);
 
         var workoutPlanWorkoutsEntity =
@@ -33,10 +34,12 @@ public class WorkoutPlanService : IWorkoutPlanService
 
         var workoutPlanId = workoutPlanWorkoutsEntity.First().WorkoutPlanId;
         var workoutPlanName = workoutPlanWorkoutsEntity.First().WorkoutPlan.Name;
+        var isWorkoutPlanActive = workoutPlanWorkoutsEntity.First().WorkoutPlan.IsActive;
 
         var workoutPlanViewModel = WorkoutPlanViewModel.Create(
             workoutPlanId: workoutPlanId,
             name: workoutPlanName,
+            isActive: isWorkoutPlanActive,
             workoutWithExercisesSetViewModel: workoutPlanWorkoutsEntity
                 .Select(w => w.Workout.ToViewModel(ExerciseSet.Create(w.Sets, w.RepsMin, w.RepsMax,
                     w.Weight, w.RestBetweenSets, w.Notes)))
@@ -60,6 +63,7 @@ public class WorkoutPlanService : IWorkoutPlanService
             .Select(x => WorkoutPlanViewModel.Create(
                 workoutPlanId: x.Id,
                 name: x.Name,
+                isActive: x.IsActive,
                 workoutWithExercisesSetViewModel: x.WorkoutPlanWorkoutEntities
                     .Select(w =>
                         w.Workout.ToViewModel(ExerciseSet.Create(w.Sets, w.RepsMin, w.RepsMax, w.Weight, w.RestBetweenSets,
@@ -111,6 +115,35 @@ public class WorkoutPlanService : IWorkoutPlanService
             _fitSyncUnitOfWork.WorkoutPlanRepository.UpdateAsync(workoutPlanEntity),
             _fitSyncUnitOfWork.WorkoutPlanWorkoutRepository.UpdateRangeAsync(workoutPlanWorkoutEntities));
 
+        await _fitSyncUnitOfWork.SaveChangesAsync();
+
+        return ServiceResponse<bool>.SuccessResult(true);
+    }
+
+    public async Task<ServiceResponse<bool>> ToggleWorkoutPlanActiveAsync(UpdateWorkoutPlanActiveOrInactiveDto
+        updateWorkoutPlanActiveOrInactiveDto)
+    {
+        _logger.LogInformation("Activating or deactivating workout plan with id {WorkoutPlanId}",
+            updateWorkoutPlanActiveOrInactiveDto.WorkoutPlanId);
+
+        var workoutPlanEntity = await _fitSyncUnitOfWork.WorkoutPlanRepository.GetByIdAsync
+            (updateWorkoutPlanActiveOrInactiveDto.WorkoutPlanId);
+
+        if (workoutPlanEntity is null)
+        {
+            _logger.LogWarning("Workout plan with id {id} not found", updateWorkoutPlanActiveOrInactiveDto.WorkoutPlanId);
+            return ServiceResponse<bool>.FailureResult("Workout plan not found");
+        }
+
+        if (workoutPlanEntity.IsActive == updateWorkoutPlanActiveOrInactiveDto.IsActive)
+        {
+           _logger.LogWarning("Can not update workout plan status, because it is already {IsActive}",
+               workoutPlanEntity.IsActive);
+           return ServiceResponse<bool>.FailureResult("Can not update workout plan status");
+        }
+
+        workoutPlanEntity.ToggleIsActive(updateWorkoutPlanActiveOrInactiveDto.IsActive);
+        await _fitSyncUnitOfWork.WorkoutPlanRepository.UpdateAsync(workoutPlanEntity);
         await _fitSyncUnitOfWork.SaveChangesAsync();
 
         return ServiceResponse<bool>.SuccessResult(true);

--- a/src/FitSync.Application/Services/WorkoutPlanService.cs
+++ b/src/FitSync.Application/Services/WorkoutPlanService.cs
@@ -48,11 +48,13 @@ public class WorkoutPlanService : IWorkoutPlanService
         return ServiceResponse<WorkoutPlanViewModel>.SuccessResult(workoutPlanViewModel);
     }
 
-    public async Task<ServiceResponse<IEnumerable<WorkoutPlanViewModel>>> GetWorkoutPlansByUserIdAsync(int userId)
+    public async Task<ServiceResponse<IEnumerable<WorkoutPlanViewModel>>> GetWorkoutPlansByUserIdAsync(int userId,
+        bool? isActive = null)
     {
         _logger.LogInformation("Getting workout plan by user id: {userId}", userId);
 
-        var workoutPlanEntity = await _fitSyncUnitOfWork.WorkoutPlanRepository.GetWorkoutPlanIncludedWorkoutsByUserIdAsync(userId);
+        var workoutPlanEntity = await _fitSyncUnitOfWork.WorkoutPlanRepository
+            .GetWorkoutPlanIncludedWorkoutsByUserIdAsync(userId, isActive);
 
         if (!workoutPlanEntity.Any())
         {

--- a/src/FitSync.Domain/Dtos/WorkoutPlans/UpdateWorkoutPlanActiveOrInactiveDto.cs
+++ b/src/FitSync.Domain/Dtos/WorkoutPlans/UpdateWorkoutPlanActiveOrInactiveDto.cs
@@ -1,0 +1,9 @@
+namespace FitSync.Domain.Dtos.WorkoutPlans;
+
+public record UpdateWorkoutPlanActiveOrInactiveDto(int WorkoutPlanId, bool IsActive)
+{
+    public static UpdateWorkoutPlanActiveOrInactiveDto Create(int workoutPlanId, bool isActive)
+    {
+        return new UpdateWorkoutPlanActiveOrInactiveDto(workoutPlanId, isActive);
+    }
+}

--- a/src/FitSync.Domain/Entities/WorkoutPlanEntity.cs
+++ b/src/FitSync.Domain/Entities/WorkoutPlanEntity.cs
@@ -6,6 +6,7 @@ public class WorkoutPlanEntity : TrackableEntity
 
     // Foreign key
     public int UserId { get; set; }
+    public bool IsActive { get; private set; } = false;
 
     // Navigation property
     public virtual UserEntity User { get; set; }
@@ -16,5 +17,10 @@ public class WorkoutPlanEntity : TrackableEntity
     public void Update(string name)
     {
         Name = name;
+    }
+
+    public void ToggleIsActive(bool isActive)
+    {
+        IsActive = isActive;
     }
 }

--- a/src/FitSync.Domain/Interfaces/IWorkoutPlanRepository.cs
+++ b/src/FitSync.Domain/Interfaces/IWorkoutPlanRepository.cs
@@ -5,5 +5,6 @@ namespace FitSync.Domain.Interfaces;
 public interface IWorkoutPlanRepository : IRepository<WorkoutPlanEntity>
 {
   Task<WorkoutPlanEntity?> GetWorkoutPlanIncludedWorkoutsAsync(int workoutPlanId);
-  Task<IReadOnlyCollection<WorkoutPlanEntity>> GetWorkoutPlanIncludedWorkoutsByUserIdAsync(int userId);
+  Task<IReadOnlyCollection<WorkoutPlanEntity>> GetWorkoutPlanIncludedWorkoutsByUserIdAsync(int userId, bool? isActive
+    = null);
 }

--- a/src/FitSync.Domain/Interfaces/IWorkoutPlanService.cs
+++ b/src/FitSync.Domain/Interfaces/IWorkoutPlanService.cs
@@ -13,5 +13,6 @@ public interface IWorkoutPlanService
         updateWorkoutPlanActiveOrInactiveDto);
     Task<ServiceResponse<bool>> DeleteWorkPlanAsync(int id);
     Task<ServiceResponse<WorkoutPlanViewModel>> GetWorkoutPlanByIdAsync(int id);
-    Task<ServiceResponse<IEnumerable<WorkoutPlanViewModel>>> GetWorkoutPlansByUserIdAsync(int userId);
+    Task<ServiceResponse<IEnumerable<WorkoutPlanViewModel>>> GetWorkoutPlansByUserIdAsync(int userId, bool? isActive
+        = null);
 }

--- a/src/FitSync.Domain/Interfaces/IWorkoutPlanService.cs
+++ b/src/FitSync.Domain/Interfaces/IWorkoutPlanService.cs
@@ -8,6 +8,9 @@ public interface IWorkoutPlanService
 {
     Task<ServiceResponse<int>> CreateWorkPlanAsync(AddWorkoutPlanDto addWorkoutPlanDto);
     Task<ServiceResponse<bool>> UpdateWorkPlanAsync(UpdateWorkoutPlanDto updateWorkoutPlanDto);
+
+    Task<ServiceResponse<bool>> ToggleWorkoutPlanActiveAsync(UpdateWorkoutPlanActiveOrInactiveDto
+        updateWorkoutPlanActiveOrInactiveDto);
     Task<ServiceResponse<bool>> DeleteWorkPlanAsync(int id);
     Task<ServiceResponse<WorkoutPlanViewModel>> GetWorkoutPlanByIdAsync(int id);
     Task<ServiceResponse<IEnumerable<WorkoutPlanViewModel>>> GetWorkoutPlansByUserIdAsync(int userId);

--- a/src/FitSync.Domain/ViewModels/WorkoutPlans/WorkoutPlanViewModel.cs
+++ b/src/FitSync.Domain/ViewModels/WorkoutPlans/WorkoutPlanViewModel.cs
@@ -2,10 +2,12 @@ using FitSync.Domain.ViewModels.Workouts;
 
 namespace FitSync.Domain.ViewModels.WorkoutPlans;
 
-public record WorkoutPlanViewModel(int WorkoutPlanId, string Name, ICollection<WorkoutWithExercisesSetViewModel> WorkoutWithExercisesSetViewModel)
+public record WorkoutPlanViewModel(int WorkoutPlanId, string Name, bool IsActive, ICollection<WorkoutWithExercisesSetViewModel>
+        WorkoutWithExercisesSetViewModel)
 {
-    public static WorkoutPlanViewModel Create(int workoutPlanId, string name, ICollection<WorkoutWithExercisesSetViewModel> workoutWithExercisesSetViewModel)
+    public static WorkoutPlanViewModel Create(int workoutPlanId, string name,
+        bool isActive, ICollection<WorkoutWithExercisesSetViewModel> workoutWithExercisesSetViewModel)
     {
-        return new WorkoutPlanViewModel(workoutPlanId, name, workoutWithExercisesSetViewModel);
+        return new WorkoutPlanViewModel(workoutPlanId, name, isActive, workoutWithExercisesSetViewModel);
     }
 }

--- a/src/FitSync.Infrastructure/Data/FitSyncDbContext.cs
+++ b/src/FitSync.Infrastructure/Data/FitSyncDbContext.cs
@@ -78,6 +78,10 @@ public class FitSyncDbContext : DbContext
             .HasKey(wp => wp.Id);
 
         modelBuilder.Entity<WorkoutPlanEntity>()
+            .Property(wp => wp.IsActive)
+            .HasColumnType("boolean");
+
+        modelBuilder.Entity<WorkoutPlanEntity>()
             .HasOne(wp => wp.User)
             .WithMany(u => u.WorkoutPlans)
             .HasForeignKey(wp => wp.UserId);

--- a/src/FitSync.Infrastructure/Migrations/20241108144559_AddedIsActiveFieldInWorkoutPlanEntity.Designer.cs
+++ b/src/FitSync.Infrastructure/Migrations/20241108144559_AddedIsActiveFieldInWorkoutPlanEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FitSync.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FitSync.Infrastructure.Migrations
 {
     [DbContext(typeof(FitSyncDbContext))]
-    partial class FitSyncDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241108144559_AddedIsActiveFieldInWorkoutPlanEntity")]
+    partial class AddedIsActiveFieldInWorkoutPlanEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FitSync.Infrastructure/Migrations/20241108144559_AddedIsActiveFieldInWorkoutPlanEntity.cs
+++ b/src/FitSync.Infrastructure/Migrations/20241108144559_AddedIsActiveFieldInWorkoutPlanEntity.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FitSync.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedIsActiveFieldInWorkoutPlanEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "WorkoutPlans",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "WorkoutPlans");
+        }
+    }
+}

--- a/src/FitSync.Infrastructure/Repositories/WorkoutPlanRepository.cs
+++ b/src/FitSync.Infrastructure/Repositories/WorkoutPlanRepository.cs
@@ -16,12 +16,19 @@ public class WorkoutPlanRepository(FitSyncDbContext fitSyncDbContext)
             .FirstOrDefaultAsync(wp => wp.Id == workoutPlanId);
     }
 
-    public async Task<IReadOnlyCollection<WorkoutPlanEntity>> GetWorkoutPlanIncludedWorkoutsByUserIdAsync(int userId)
+    public async Task<IReadOnlyCollection<WorkoutPlanEntity>> GetWorkoutPlanIncludedWorkoutsByUserIdAsync(int userId,
+        bool? isActive = null)
     {
-        return await SetAsTracking
+        var query = SetAsTracking
             .Include(wp => wp.WorkoutPlanWorkoutEntities)
             .ThenInclude(wp => wp.Workout)
-            .Where(x => x.UserId == userId)
-            .ToListAsync();
+            .Where(x => x.UserId == userId);
+
+        if (isActive.HasValue)
+        {
+            query = query.Where(x => x.IsActive == isActive.Value);
+        }
+
+        return await query.ToListAsync();
     }
 }

--- a/src/FitSync.IntegrationTests/Controllers/WorkoutPlanControllerTests.cs
+++ b/src/FitSync.IntegrationTests/Controllers/WorkoutPlanControllerTests.cs
@@ -83,7 +83,7 @@ public class WorkoutPlanControllerTests : DatabaseTest
     }
 
     [Fact]
-    public async Task GetWorkoutPlansByUserId_ReturnsOk()
+    public async Task GetWorkoutPlansByUserIdAsync_ReturnsOk()
     {
         // Arrange
         var userId = await CreateUserAsync();
@@ -103,7 +103,7 @@ public class WorkoutPlanControllerTests : DatabaseTest
     }
 
     [Fact]
-    public async Task GetWorkoutPlansByUserId_ReturnsNotFound()
+    public async Task GetWorkoutPlansByUserIdAsync_ReturnsNotFound()
     {
         // Arrange
         var id = 0;

--- a/src/FitSync.IntegrationTests/Controllers/WorkoutPlanControllerTests.cs
+++ b/src/FitSync.IntegrationTests/Controllers/WorkoutPlanControllerTests.cs
@@ -188,4 +188,52 @@ public class WorkoutPlanControllerTests : DatabaseTest
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    [Fact]
+    public async Task ToggleWorkoutPlanActiveAsync_ShouldReturnNoContent()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var workoutId = await CreateWorkoutAsync();
+
+        var workoutPlanId = await CreateWorkoutPlanAsync(userId, workoutId);
+
+        // Act
+        var response = await Client.PatchAsJsonAsync($"api/workout-plans/{workoutPlanId}/toggle-active", true);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task ToggleWorkoutPlanActiveAsync_ShouldReturnNotFound()
+    {
+        // Arrange
+        // Act
+        var response = await Client.PatchAsJsonAsync($"api/workout-plans/{0}/toggle-active", true);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToggleWorkoutPlanActiveAsync_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var workoutId = await CreateWorkoutAsync();
+
+        var workoutPlanId = await CreateWorkoutPlanAsync(userId, workoutId);
+        var status = false;
+
+        // Act
+        var response = await Client.PatchAsJsonAsync($"api/workout-plans/{workoutPlanId}/toggle-active", status);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var errorMessage = await response.Content.ReadAsStringAsync();
+        errorMessage.Should().Be("Can not update workout plan status",
+            because: "Because it is already {IsActive}", status);
+    }
 }

--- a/src/FitSync.UnitTests/CalendarServiceTests.cs
+++ b/src/FitSync.UnitTests/CalendarServiceTests.cs
@@ -30,6 +30,7 @@ public class CalendarServiceTests
                         WorkoutPlanViewModel.Create(
                             workoutPlanId: 1,
                             name: "Workout Plan 1",
+                            isActive: false,
                             workoutWithExercisesSetViewModel: new List<WorkoutWithExercisesSetViewModel>()
                             {
                                 WorkoutWithExercisesSetViewModel.Create(
@@ -92,6 +93,7 @@ public class CalendarServiceTests
                         WorkoutPlanViewModel.Create(
                             workoutPlanId: 2,
                             name: "Workout Plan 2",
+                            isActive: false,
                             workoutWithExercisesSetViewModel: new List<WorkoutWithExercisesSetViewModel>()
                             {
                                 WorkoutWithExercisesSetViewModel.Create(
@@ -120,6 +122,7 @@ public class CalendarServiceTests
                         WorkoutPlanViewModel.Create(
                             workoutPlanId: 3,
                             name: "Workout Plan 3",
+                            isActive: false,
                             workoutWithExercisesSetViewModel: new List<WorkoutWithExercisesSetViewModel>()
                             {
                                 WorkoutWithExercisesSetViewModel.Create(
@@ -144,6 +147,7 @@ public class CalendarServiceTests
                         WorkoutPlanViewModel.Create(
                             workoutPlanId: 4,
                             name: "Workout Plan 4",
+                            isActive: false,
                             workoutWithExercisesSetViewModel: new List<WorkoutWithExercisesSetViewModel>()
                             {
                                 WorkoutWithExercisesSetViewModel.Create(

--- a/src/FitSync.UnitTests/WorkoutPlanServiceTests.cs
+++ b/src/FitSync.UnitTests/WorkoutPlanServiceTests.cs
@@ -207,4 +207,109 @@ public class WorkoutPlanServiceTests : DataBaseTest<WorkoutPlanService>
         var workoutPlan = await _fitSyncUnitOfWork.WorkoutPlanRepository.GetByIdAsync(workoutPlanEntity.Id);
         workoutPlan.Should().BeNull();
     }
+
+
+    [Fact]
+    public async Task UpdateWorkoutPlanIsActiveProperty_ShouldUpdateWorkoutPlan()
+    {
+        // Arrange
+        var userEntity = AddUserDto.Create("Test", 25, Genre.Male).ToDomainEntity();
+
+        var workoutEntity = new Faker<AddWorkoutDto>()
+            .CustomInstantiator(w => new AddWorkoutDto(
+                Title: w.Random.String(),
+                Description: w.Random.String(),
+                Type: w.PickRandom<WorkoutType>(),
+                BodyPart: w.Random.String(),
+                Equipment: w.Random.String(),
+                Level: w.PickRandom<WorkoutLevel>()))
+            .Generate()
+            .ToDomainEntity();
+
+        await Task.WhenAll(
+            _fitSyncUnitOfWork.UserRepository.AddAsync(userEntity),
+            _fitSyncUnitOfWork.WorkoutRepository.AddAsync(workoutEntity)
+        );
+
+        await _fitSyncUnitOfWork.SaveChangesAsync();
+
+        var workoutPlanEntity = AddWorkoutPlanDto.Create(userEntity.Id, Faker.Random.String(),
+            new Dictionary<int, ExerciseSet>()
+            {
+                { workoutEntity.Id, new ExerciseSet(3, 10, 15, 60,
+                    Faker.Random.Int(),Faker.Random.String() ) }
+            }).ToDomainEntity();
+
+        await _fitSyncUnitOfWork.WorkoutPlanRepository.AddAsync(workoutPlanEntity);
+        await _fitSyncUnitOfWork.SaveChangesAsync();
+
+        workoutPlanEntity.IsActive.Should().BeFalse();
+
+        var updateWorkoutPlanActiveOrInactiveDto = UpdateWorkoutPlanActiveOrInactiveDto.Create(workoutPlanEntity.Id,
+            true);
+
+        // Act
+        var result = await _workoutPlanService.ToggleWorkoutPlanActiveAsync
+            (updateWorkoutPlanActiveOrInactiveDto);
+
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Data.Should().BeTrue();
+
+        var workoutPlanViewModel = await _workoutPlanService.GetWorkoutPlanByIdAsync(workoutPlanEntity.Id)
+            .ContinueWith(x => x.Result.Data!);
+
+        workoutPlanViewModel.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task
+        UpdateWorkoutPlanIsActiveProperty_WhenTheInputIsTheSameAsTheExistingProperty_ShouldReturnErrorMessage()
+    {
+        // Arrange
+        var userEntity = AddUserDto.Create("Test", 25, Genre.Male).ToDomainEntity();
+
+        var workoutEntity = new Faker<AddWorkoutDto>()
+            .CustomInstantiator(w => new AddWorkoutDto(
+                Title: w.Random.String(),
+                Description: w.Random.String(),
+                Type: w.PickRandom<WorkoutType>(),
+                BodyPart: w.Random.String(),
+                Equipment: w.Random.String(),
+                Level: w.PickRandom<WorkoutLevel>()))
+            .Generate()
+            .ToDomainEntity();
+
+        await Task.WhenAll(
+            _fitSyncUnitOfWork.UserRepository.AddAsync(userEntity),
+            _fitSyncUnitOfWork.WorkoutRepository.AddAsync(workoutEntity)
+        );
+
+        await _fitSyncUnitOfWork.SaveChangesAsync();
+
+        var workoutPlanEntity = AddWorkoutPlanDto.Create(userEntity.Id, Faker.Random.String(),
+            new Dictionary<int, ExerciseSet>()
+            {
+                { workoutEntity.Id, new ExerciseSet(3, 10, 15, 60,
+                    Faker.Random.Int(),Faker.Random.String() ) }
+            }).ToDomainEntity();
+
+        await _fitSyncUnitOfWork.WorkoutPlanRepository.AddAsync(workoutPlanEntity);
+        await _fitSyncUnitOfWork.SaveChangesAsync();
+
+        workoutPlanEntity.IsActive.Should().BeFalse();
+
+        var updateWorkoutPlanActiveOrInactiveDto = UpdateWorkoutPlanActiveOrInactiveDto.Create(workoutPlanEntity.Id,
+            false);
+
+        // Act
+        var result = await _workoutPlanService.ToggleWorkoutPlanActiveAsync
+            (updateWorkoutPlanActiveOrInactiveDto);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Data.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Can not update workout plan status");
+    }
 }


### PR DESCRIPTION
- Added `isActive` field to the `WorkoutPlanEntity` to track the active status of workout plans.
- Implemented `ToggleIsActive` method to enable toggling the active status on and off.
- Added API endpoint and corresponding service method `ToggleWorkoutPlanActiveAsync` for updating the active status via the API.
- Developed unit tests to ensure the functionality of the new method and endpoint.
- Created integration tests to validate the end-to-end behavior of the updated functionality.
- Added migration `20241108144559_AddedIsActiveFieldInWorkoutPlanEntity` to update the database schema with the new field.
- Introduced an optional `IsActive` parameter to the `GetWorkoutPlansByUserIdAsync` method to allow filtering of workout plans based on their active status.
- Updated unit tests to cover scenarios with the new `IsActive` parameter.
- Updated integration tests to validate the filtering behavior in real-world scenarios.